### PR TITLE
add --no-mount tmp for singularity destination in tests

### DIFF
--- a/test/integration/embedded_pulsar_singularity_job_conf.yml
+++ b/test/integration/embedded_pulsar_singularity_job_conf.yml
@@ -13,6 +13,8 @@ execution:
       runner: pulsar_embed
       singularity_enabled: true
       singularity_required: true
+      # since tests run in /tmp/ we apparently need to forbid the default mounting of /tmp
+      singularity_run_extra_arguments: '--no-mount tmp'
 
 tools:
 - class: local

--- a/test/integration/singularity_job_conf.yml
+++ b/test/integration/singularity_job_conf.yml
@@ -10,6 +10,8 @@ execution:
     local_singularity:
       runner: local
       singularity_enabled: true
+      # since tests run in /tmp/
+      singularity_run_extra_arguments: '--no-mount tmp'
     local_upload:
       runner: local
 

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -168,7 +168,6 @@ class TestDockerizedJobsIntegration(BaseJobEnvironmentIntegrationTestCase, Mulle
         assert identifier.startswith(f"quay.io/local/{expected_hash}")
 
 
-
 class TestMappingContainerResolver(integration_util.IntegrationTestCase):
     dataset_populator: DatasetPopulator
     jobs_directory: str

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -157,7 +157,7 @@ class TestDockerizedJobsIntegration(BaseJobEnvironmentIntegrationTestCase, Mulle
         assert status[0]["dependency_type"] == self.container_type
         self._assert_container_description_identifier(
             status[0]["container_description"]["identifier"],
-            "mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:a6419f25efff953fc505dbd5ee734856180bb619-0"
+            "mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:a6419f25efff953fc505dbd5ee734856180bb619-0",
         )
 
     def _assert_container_description_identifier(self, identifier, expected_hash):

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -155,7 +155,18 @@ class TestDockerizedJobsIntegration(BaseJobEnvironmentIntegrationTestCase, Mulle
         status = response[0]["status"]
         assert status[0]["model_class"] == "ContainerDependency"
         assert status[0]["dependency_type"] == self.container_type
-        assert status[0]["container_description"]["identifier"].startswith("quay.io/local/mulled-v2-")
+        self._assert_container_description_identifier(
+            status[0]["container_description"]["identifier"],
+            "mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:a6419f25efff953fc505dbd5ee734856180bb619-0"
+        )
+
+    def _assert_container_description_identifier(self, identifier, expected_hash):
+        """
+        helper function to assert a correct container identifier
+        needs to be overwritten for singularity tests
+        """
+        assert identifier.startswith(f"quay.io/local/{expected_hash}")
+
 
 
 class TestMappingContainerResolver(integration_util.IntegrationTestCase):
@@ -256,11 +267,11 @@ class TestInlineJobEnvironmentContainerResolver(integration_util.IntegrationTest
         assert "0.7.15-r1140" in output
 
 
-# Singularity 2.4 in the official Vagrant issue has some problems running this test
-# case by default because subdirectories of /tmp don't bind correctly. Overridding
-# TMPDIR can fix this.
-# TMPDIR=/home/vagrant/tmp/ pytest test/integration/test_containerized_jobs.py::TestSingularityJobsIntegration
 class TestSingularityJobsIntegration(TestDockerizedJobsIntegration):
     job_config_file = SINGULARITY_JOB_CONFIG_FILE
     build_mulled_resolver = "build_mulled_singularity"
     container_type = "singularity"
+
+    def _assert_container_description_identifier(self, identifier, expected_hash):
+        assert os.path.exists(identifier)
+        assert identifier.endswith(f"singularity/mulled/{expected_hash}")


### PR DESCRIPTION
Hi @nsoranzo this fixes all but one of the tests in `test/integration/test_containerized_jobs.py::TestSingularityJobsIntegration`, e.g. `test_explicit` failed with `FATAL:   container creation failed: mount /tmp/tmpfr6yrqr6/000/1->/tmp/tmpfr6yrqr6/000/1 error: while mounting /tmp/tmpfr6yrqr6/000/1: destination /tmp/tmpfr6yrqr6/000/1 doesn't exist in container`

Edit: The 2nd commit also fixes the `test_build_mulled` tests for singularity.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT).
